### PR TITLE
fix: promises should resolve correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -50,6 +50,9 @@ function step(context: Context) {
   // scroll more if we have not reached our destination
   if (currentX !== context.x || currentY !== context.y) {
     requestAnimationFrame(() => step(context))
+  } else {
+    // If nothing left to scroll lets fire the callback
+    context.cb()
   }
 }
 


### PR DESCRIPTION
Fixes use cases where code like this might never resolve:
```js
scrollIntoView([HTMLElement], {
  scrollMode: 'if-needed',
  block: 'nearest'
}).then(() => { console.log('done') })
```

Fixes https://github.com/stipsan/scroll-into-view-if-needed/issues/344