### PR TITLE
feat(cancellation): support AbortController signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ const sequence = async () => {
 }
 ```
 
+The promise interface allows more advanced use cases, like a custom waterfall effect seen here: https://codepen.io/stipsan/pen/gjwWXV
+
 ## Polyfills
 
 This library rely on `Promise` and `requestAnimationFrame`. This library does not ship with polyfills for these to keep bundlesizes as low as possible.


### PR DESCRIPTION
Transitions can now be aborted by passing an abort signal, as defined by: https://dom.spec.whatwg.org/#aborting-ongoing-activities