### PR TITLE
SmoothBehaviorOptions typing is fixed:

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ type OnScrollChangeCallback = (scrollState: {
   top: number
 }) => void
 
-export interface SmoothBehaviorOptions extends Options {
+export type SmoothBehaviorOptions = Options & {
   behavior?: 'smooth'
   duration?: number
   ease?: CustomEasing


### PR DESCRIPTION
SmoothBehaviorOptions is updated to be a type alias instead of an interface since Options cannot be extended from because it's an interface too.

Fixes: #1050 